### PR TITLE
Easier to read small text

### DIFF
--- a/server/release/public/main.css
+++ b/server/release/public/main.css
@@ -18,5 +18,5 @@ html {
 
 .widget {
   position: absolute;
-  -webkit-font-smoothing: subpixel-antialiased;
+  -webkit-font-smoothing: antialiased;
 }


### PR DESCRIPTION
I think subpixel-antialiased is the default, and thus unneeded. But it's hard to read small text with that.
Example: the "network throughput" text at the top of that widget.
Changing to antialiased makes it much more readable, but also changes the boldness of a lot of the fonts in the existing widgets.
Maybe you want to keep it at subpixel-antialiased in main.css, and just modify the widgets to use -webkit-font-smoothing: antialiased; just for the smaller text..?
Personally, I prefer how my widget look now that I changed it at the "top level" like this.
