### PR TITLE
Remember preferred screens, when user selects one from the menu.

### DIFF
--- a/Übersicht/UBAppDelegate.m
+++ b/Übersicht/UBAppDelegate.m
@@ -21,7 +21,6 @@
     UBPreferencesController* preferences;
     BOOL keepServerAlive;
     WebInspector *inspector;
-    uint32 lastScreenNumber;
 }
 
 @synthesize window;
@@ -32,10 +31,8 @@
     statusBarItem = [self addStatusItemToMenu: statusBarMenu];
     preferences   = [[UBPreferencesController alloc] initWithWindowNibName:@"UBPreferencesController"];
     
-    if ([NSScreen.screens count] > 1)
-        [self addScreensToMenu:statusBarMenu];
-    
-    [self sendWindowToScreen:CGMainDisplayID()];
+    // Handles the screen entries in the menu, and will send the window to the user's preferred screen
+    [self screensChanged:self];
 
     keepServerAlive = YES;
     [self startServer];
@@ -300,39 +297,69 @@ static CFDictionaryRef getDisplayInfoDictionary(CGDirectDisplayID displayID)
     CGDirectDisplayID displays[20];
     uint32_t numDisplays;
     uint32 screenId;
-    BOOL foundScreenAgain = NO;
     
     CGGetActiveDisplayList(20, displays, &numDisplays);
 
     [self removeScreensFromMenu:statusBarMenu];
     
-    if (numDisplays > 1)
+    if (numDisplays > 1) {
         [self addScreensToMenu:statusBarMenu];
-    
-    for (int i = 0; i < numDisplays; i++) {
-        screenId = displays[i];
-        if (CGDisplayIsInMirrorSet(screenId))
-            continue;
-        
-        if (lastScreenNumber == CGDisplayUnitNumber(screenId)) {
-            foundScreenAgain = YES;
-            [self sendWindowToScreen:screenId];
-        }
     }
     
-    if (!foundScreenAgain)
-        [self sendWindowToScreen:CGMainDisplayID()];
-        
+    // Most recently preferred screens will be listed first, so the first match we found will be the preferred screen.
+    NSArray* preferredScreens = [self getPreferredScreens];
+    for (int i = 0; i < preferredScreens.count; i++) {
+        NSInteger preferredScreenNumber = [preferredScreens[i] integerValue];
+        for (int j = 0; j < numDisplays; j++) {
+            screenId = displays[j];
+            if (CGDisplayIsInMirrorSet(screenId))
+                continue;
+            
+            if (preferredScreenNumber == CGDisplayUnitNumber(screenId)) {
+                [self sendWindowToScreen:screenId];
+                return;
+            }
+        }
+    }
+    // Couldn't find a preferred screen; use the primary display
+    [self sendWindowToScreen:CGMainDisplayID()];
 }
 
 - (void)sendWindowToScreen:(CGDirectDisplayID)screenId
 {
     [window fillScreen:screenId];
-    lastScreenNumber = CGDisplayUnitNumber(screenId);
     
     [self markScreen:screenId inMenu:statusBarMenu];
 }
 
+- (NSMutableArray*)getPreferredScreens
+{
+    NSMutableArray* preferredScreens;
+    NSArray* preferredScreensPref = [[NSUserDefaults standardUserDefaults]
+                                     objectForKey:@"preferredScreens"];
+    if (!preferredScreensPref) {
+        preferredScreensPref = @[];
+    }
+    preferredScreens = [NSMutableArray arrayWithArray:preferredScreensPref];
+    return preferredScreens;
+}
+
+- (void)setPreferredScreen:(CGDirectDisplayID)screenId
+{
+    NSNumber* displayNumber = @(CGDisplayUnitNumber(screenId));
+    
+    // Add displayNumber to the preferredScreens user default array.
+    // Also make sure it's only in there once (i.e. remove it first)
+    
+    NSMutableArray* preferredScreens = [self getPreferredScreens];
+    [preferredScreens removeObject:displayNumber];
+    // Most recently preferred screens are at the beginning of the array
+    [preferredScreens insertObject:displayNumber atIndex:0];
+
+    [[NSUserDefaults standardUserDefaults]
+     setObject:preferredScreens forKey:@"preferredScreens"];
+    [[NSUserDefaults standardUserDefaults] synchronize];
+}
 
 #
 # pragma mark received actions
@@ -341,6 +368,7 @@ static CFDictionaryRef getDisplayInfoDictionary(CGDirectDisplayID displayID)
 - (void)screenWasSelected:(id)sender
 {
     [self sendWindowToScreen:(CGDirectDisplayID)[sender tag]];
+    [self setPreferredScreen:(CGDirectDisplayID)[sender tag]];
 }
 
 - (void)widgetDirDidChange


### PR DESCRIPTION
Re-use it each time it's available.
Most recently selected screen will be used first, and if not present, other previously selected screens can be used.
