### PR TITLE
Add rudimentary location support

### DIFF
--- a/Übersicht/UBWindow.h
+++ b/Übersicht/UBWindow.h
@@ -13,8 +13,9 @@
 #import <Cocoa/Cocoa.h>
 #import <WebKit/WebKit.h>
 #import <JavaScriptCore/JavaScriptCore.h>
+#import <CoreLocation/CoreLocation.h>
 
-@interface UBWindow : NSWindow
+@interface UBWindow : NSWindow <CLLocationManagerDelegate>
 
 @property (weak) IBOutlet WebView *webView;
 

--- a/Übersicht/UBWindow.m
+++ b/Übersicht/UBWindow.m
@@ -208,10 +208,7 @@
 
 - (void)locationManager:(CLLocationManager *)manager didUpdateToLocation:(CLLocation *)newLocation fromLocation:(CLLocation *)oldLocation
 {
-    NSLog(@"locationManager:(CLLocationManager *)manager didUpdateToLocation");
     // Only notify the webview if the location has actually changed
-    NSLog(@"old: %f %f", oldLocation.coordinate.latitude, oldLocation.coordinate.longitude);
-    NSLog(@"new: %f %f", newLocation.coordinate.latitude, newLocation.coordinate.longitude);
     if (!oldLocation || !CLCOORDINATES_EQUAL2(newLocation.coordinate, oldLocation.coordinate)) {
         [self notifyWebviewOfLocationChange:newLocation];
     }
@@ -219,7 +216,6 @@
 
 - (void)locationManager:(CLLocationManager *)manager didFailWithError:(NSError *)error
 {
-    NSLog(@"%@", error);
     [self notifyWebviewOfLocationChange:nil];
 }
 
@@ -240,8 +236,6 @@
 
 - (void)notifyWebviewOfLocationChange:(CLLocation *)location
 {
-    NSLog(@"DEBUG notifyWebviewOfLocationChange");
-    
     // It may make more sense to retain the last known location so widgets will continue to
     // work until there's another valid location
     if (!location) {

--- a/server/release/server.js
+++ b/server/release/server.js
@@ -1833,6 +1833,7 @@ module.exports = function(implementation) {
   };
   api.id = 'widget';
   api.refreshFrequency = 1000;
+  api.refreshOnLocationChange = false;
   api.render = function(output) {
     if (api.command && output) {
       return output;
@@ -1848,6 +1849,12 @@ module.exports = function(implementation) {
     contentEl.className = 'widget';
     el.innerHTML = "<style>" + implementation.css + "</style>\n";
     el.appendChild(contentEl);
+    if (api.refreshOnLocationChange) {
+      el.addEventListener('onlocationchange', function(_) {
+        console.log('refresh because location changed');
+        return refresh();
+      });
+    }
     return el;
   };
   api.destroy = function() {

--- a/server/release/server.js
+++ b/server/release/server.js
@@ -1851,7 +1851,6 @@ module.exports = function(implementation) {
     el.appendChild(contentEl);
     if (api.refreshOnLocationChange) {
       el.addEventListener('onlocationchange', function(_) {
-        console.log('refresh because location changed');
         return refresh();
       });
     }

--- a/server/src/os_bridge.coffee
+++ b/server/src/os_bridge.coffee
@@ -1,5 +1,15 @@
 cachedWallpaper = new Image()
 
+window.addEventListener 'onlocationchange', (e) ->
+  # When new widgets come online (including those available at launch)
+  # it's unlikely that an event will be sent soon enough with the
+  # current position. We'll watch for position changes here and cache
+  # the current value to send to widgets as they are created
+  if e.detail && e.detail.position
+    console.log 'Caching current position globally'
+    console.log e.detail.position
+    window._ub_location_position = e.detail.position
+
 window.addEventListener 'onwallpaperchange', ->
   slices = getWallpaperSlices()
   return unless slices.length > 0

--- a/server/src/widget.coffee
+++ b/server/src/widget.coffee
@@ -39,6 +39,8 @@ module.exports = (implementation) ->
 
   api.refreshFrequency = 1000
 
+  api.refreshOnLocationChange = false
+
   api.render = (output) ->
     if api.command and output
       output
@@ -55,6 +57,13 @@ module.exports = (implementation) ->
     contentEl.className = 'widget'
     el.innerHTML = "<style>#{implementation.css}</style>\n"
     el.appendChild(contentEl)
+
+    # If the widget opts in to location changes, call
+    # update whenever the `onlocationchange` event is fired
+    if api.refreshOnLocationChange
+      el.addEventListener 'onlocationchange', (_) ->
+        refresh()
+
     el
 
   api.destroy = ->


### PR DESCRIPTION
This is an ***untested*** proof-of-concept for how #59 could get handled. I didn't dig too much into how the server is actually wired up to the `UBWindow`, so there could be an issue with this particular approach where the widgets are loading before the location data is injected to the webview's `window`.

It also probably makes more sense to have the location delegate use `callWebScriptMethod:withArguments:` when the location changes, so the script could actually respond to the changes. This probably just needs to call `refresh`, or there could be a more explicit function that gets called. 

Happy to spend more time on this if it's something you think would make it in. 