### PR TITLE
Disable rubber-band/overflow scrolling.

### DIFF
--- a/server/release/public/main.css
+++ b/server/release/public/main.css
@@ -5,6 +5,7 @@ html {
   margin: 0;
   height: 100%;
   width: 100%;
+  overflow: hidden;
 }
 
 .content {


### PR DESCRIPTION
Prevents the user from scrolling past the screen causing it to snap back to frame when released.