### PR TITLE
Make a symlink from server/release/public to server/src/public

### DIFF
--- a/server/src/public
+++ b/server/src/public
@@ -1,0 +1,1 @@
+../release/public/


### PR DESCRIPTION
When the server is run from coffeescript, it expects to find the `public` dir in the cwd. This makes such a folder exist.

This only seems to crop up when running the `coffee server/server.coffee` command manually, from `server/src/app.coffee` L15: 

```coffee
server = connect()
  .use(connect.static(path.resolve(__dirname, './public')))
```

However, the cwd is `server/src`, not `server/release`, so the `public` folder doesn't exist. This just symlinks `server/release/public` to `server/src/public`.