### PR TITLE
Correct filepaths if widget directory is a symlink

### DIFF
--- a/server/src/widget_directory_watcher.coffee
+++ b/server/src/widget_directory_watcher.coffee
@@ -17,6 +17,16 @@ module.exports = (directoryPath) ->
 
     watcher = fsevents directoryPath
     watcher.on 'change', (filePath, info) ->
+
+      # fsevents returns decomposed Unicode and fs returns precomposed Unicode
+      # so normalize() is used to convert "U\xCC\x88" to "\xC3\x9C"
+      filePath = filePath.normalize()
+
+      # checks if widget directory is a symbolic link and ensures the correct path
+      if fs.lstatSync(directoryPath).isSymbolicLink()
+        symbolicLinkPath = fs.readlinkSync(directoryPath)
+        filePath = directoryPath + filePath.slice(symbolicLinkPath.length)
+
       switch info.event
         when 'modified', 'moved-in', 'created'
           findWidgets filePath, info.type, (widgetPath) ->


### PR DESCRIPTION
If [Mackup](https://github.com/lra/mackup) is used, the widgets directory will be symbolically linked from `~/Dropbox/Mackup/Library/Application Support/Übersicht/widgets`. This itself does not cause a problem but if widgets are updated while Übersicht is running then `fsevents` will return the Dropbox path to the widget which results in an HTTP request to `http://127.0.0.1:41416/widgets/<absolute path>-<widget>-index-coffee` resulting in a 404.

The solution is to check if the widgets directory is a symbolic link and replace the file path when files change.

The `unorm` module is used as well for normalizing strings as `fsevents` returns strings in decomposed UTF-8 and `fs` returns the composed form, this leads to different string lengths with the "Ü" character.