### PR TITLE
Fix UBWindow issues for Xcode 7.3

### DIFF
--- a/Uebersicht/UBAppDelegate.m
+++ b/Uebersicht/UBAppDelegate.m
@@ -334,7 +334,8 @@ int const PORT = 41416;
 - (IBAction)refreshWidgets:(id)sender
 {
     for (NSNumber* screenId in windows) {
-        [windows[screenId] reload];
+        UBWindow* window = windows[screenId];
+        [window reload];
     }
 }
 
@@ -368,7 +369,8 @@ int const PORT = 41416;
 - (void)wakeFromSleep:(NSNotification *)notification
 {
     for (NSNumber* screenId in windows) {
-        [windows[screenId] reload];
+        UBWindow* window = windows[screenId];
+        [window reload];
     }
 }
 


### PR DESCRIPTION
XCode 7.3 clang complained that multiple "reload" methods existed for instances in windows field at compile-time. I just explicitly cast each pointer to a UBWindow* to specify exactly which reload method to use.