### PR TITLE
Adding CORS proxy

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -32,6 +32,7 @@
     "browserify": "^13.0.0",
     "coffeeify": "^2.0.1",
     "connect": "~2.9.0",
+    "cors-anywhere": "^0.4.0",
     "escodegen": "^1.8.0",
     "esprima": "^2.7.2",
     "fsevents": "^1.0.6",

--- a/server/server.coffee
+++ b/server/server.coffee
@@ -1,5 +1,6 @@
 parseArgs = require 'minimist'
 UebersichtServer = require './src/app.coffee'
+cors_proxy = require 'cors-anywhere'
 
 handleError = (e) ->
   console.log 'Error:', e.message
@@ -14,6 +15,17 @@ try
     console.log 'server started on port', port
   )
   server.on 'close', handleError
+
+  cors_host = '127.0.0.1' # bind to loopback only
+  cors_port = 41417 # maybe use: port + 1
+  cors_proxy.createServer(
+    originWhitelist: ['http://127.0.0.1:' + port]
+    requireHeader: ['origin']
+    removeHeaders: ['cookie']
+  ).listen(cors_port, cors_host, ->
+    console.log 'CORS Anywhere on port', cors_port
+  )
+
 catch e
   handleError e
 


### PR DESCRIPTION
Adds a CORS proxy to allow widgets native AJAX access to servers without access-control-allow-origin headers.
- Binds to loopback
- Allows only AJAX (Origin request header)
- Only request originating from Übersicht port.

This enables widgets to replace most `curl` commands with fast and flexible native AJAX calls, playing to the strength of the JS environment.
- Fast: no need to fork a shell and curl each refresh
- Flexible: multiple and parameterized AJAX calls are simple

E.g.

```
command: (callback) ->
  proxy    = "http://127.0.0.1:41417/"
  server   = "http://example.com:8080"
  path      = "/getsomejson"
  $.get proxy + server + path, (json) ->
    callback null, json
```

(My first idea was to disable CORS requirements in WKWebView with webSecurityEnabled but that doesn't seem to be around anymore and would be private anyway.)