### PR TITLE
Add a TravisCI config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,15 @@
+os: osx
+language: objective-c
+osx_image: xcode8.3
+node_js: 5.1.1
+
+before_install:
+  - cd server
+
+install:
+  - npm install
+
+script:
+  - npm run build-server
+  - npm run build-client
+  - npm run test-local

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,11 @@ before_install:
 
 install:
   - npm install
+  - brew install phantomjs
 
 script:
   - npm run build-server
   - npm run build-client
+
   - npm run test-local
-  - npm run test-browser
+  - npm run test-browser-phantom

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,12 +9,8 @@ before_install:
 install:
   - npm install
 
-before_script:
-  - "export DISPLAY=:99.0"
-  - "sh -e /etc/init.d/xvfb start"
-  - sleep 3 # give xvfb some time to start
-
 script:
   - npm run build-server
   - npm run build-client
   - npm run test-local
+  - npm run test-browser

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,11 @@ before_install:
 install:
   - npm install
 
+before_script:
+  - "export DISPLAY=:99.0"
+  - "sh -e /etc/init.d/xvfb start"
+  - sleep 3 # give xvfb some time to start
+
 script:
   - npm run build-server
   - npm run build-client

--- a/server/package.json
+++ b/server/package.json
@@ -7,6 +7,7 @@
     "test": "npm run-script test-local && npm run-script test-browser",
     "test-local": "tape -r coffee-script/register spec/backend/**/* | tap-spec",
     "test-browser": "browserify -t coffeeify -t [babelify --presets es2015] spec/frontend/*.*  | tape-run | tap-spec",
+    "test-browser-phantom": "browserify -t coffeeify -t [babelify --presets es2015] spec/frontend/*.*  | tape-run --browser phantom | tap-spec",
     "start": "coffee server.coffee",
     "release": "npm run-script build-client && npm run-script build-server",
     "build-client": "browserify -i ws -t coffeeify -t [babelify --presets es2015] -r ./src/runShellCommand.js:run client.coffee | uglifyjs -c --screw-ie8 > release/public/client.js",


### PR DESCRIPTION
In my projects, I've found it really helpful to set up a CI (continuous integration) service. As @bauen1 eloquently put it,

> It wouldn't have to actually build stuff, just run the tests which really helps if you commit stuff and are too lazy / don't have the time to do a clean build beforehand.

This PR sets up Travis to start up an OS X 10.12 VM with node 5.1.1 (they have 10.10 through 10.12 available), and then run `npm run build-server`, `npm run build-client`, and `npm run test-local`. I can add the `test-browser` command at a later date.

@felixhageloh: All you will need to do is: 
- open https://travis-ci.org and log in with your GitHub account
- flip the "on" switch next to Uebersicht in the list of repositories

You'll likely want to go into the [Settings](https://travis-ci.org/felixhageloh/uebersicht/settings) screen and turn on the "Build only if .travis.yml is present" option so Travis won't start failing your builds on `master` while you review this PR, as well.

Closes #263.