### PR TITLE
Changes to build on M1

### DIFF
--- a/Podfile.lock
+++ b/Podfile.lock
@@ -7,7 +7,7 @@ DEPENDENCIES:
   - Sparkle
 
 SPEC REPOS:
-  https://github.com/cocoapods/specs.git:
+  trunk:
     - SocketRocket
     - Sparkle
 
@@ -17,4 +17,4 @@ SPEC CHECKSUMS:
 
 PODFILE CHECKSUM: f68839bf85fc3a629cc21d58a289a00e2eaaa792
 
-COCOAPODS: 1.7.5
+COCOAPODS: 1.10.2

--- a/Uebersicht.xcodeproj/project.pbxproj
+++ b/Uebersicht.xcodeproj/project.pbxproj
@@ -555,7 +555,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "export PATH=$PATH:/usr/local/bin\ncd server && npm run-script release\n";
+			shellScript = "export PATH=$PATH:/usr/local/bin:/opt/homebrew/bin\ncd server && npm run-script release\n";
 		};
 		DC92346F23015178009D9E2F /* Run Script */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -26,7 +26,7 @@
         "emotion": "^10.0.27",
         "escodegen": "^1.14.3",
         "esprima": "^2.7.3",
-        "fsevents": "^2.1.3",
+        "fsevents": "^2.3",
         "jquery": "^3.5.1",
         "minimist": "^1.2.5",
         "ms": "^2.0.0",
@@ -3058,9 +3058,10 @@
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
     "node_modules/fsevents": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.3.tgz",
-      "integrity": "sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "hasInstallScript": true,
       "os": [
         "darwin"
       ],
@@ -9416,9 +9417,9 @@
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
     "fsevents": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.3.tgz",
-      "integrity": "sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ=="
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="
     },
     "function-bind": {
       "version": "1.1.1",

--- a/server/package.json
+++ b/server/package.json
@@ -41,7 +41,7 @@
     "emotion": "^10.0.27",
     "escodegen": "^1.14.3",
     "esprima": "^2.7.3",
-    "fsevents": "^2.1.3",
+    "fsevents": "^2.3",
     "jquery": "^3.5.1",
     "minimist": "^1.2.5",
     "ms": "^2.0.0",

--- a/server/release/package-lock.json
+++ b/server/release/package-lock.json
@@ -26,7 +26,7 @@
         "emotion": "^10.0.27",
         "escodegen": "^1.14.3",
         "esprima": "^2.7.3",
-        "fsevents": "^2.1.3",
+        "fsevents": "^2.3",
         "jquery": "^3.5.1",
         "minimist": "^1.2.5",
         "ms": "^2.0.0",
@@ -2947,9 +2947,10 @@
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
     "node_modules/fsevents": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.3.tgz",
-      "integrity": "sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "hasInstallScript": true,
       "os": [
         "darwin"
       ],
@@ -9129,9 +9130,9 @@
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
     "fsevents": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.3.tgz",
-      "integrity": "sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ=="
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="
     },
     "function-bind": {
       "version": "1.1.1",


### PR DESCRIPTION
This is on the road to a #444 fix at least.

I also had to run `brew install cocoapods; pod install` (but didn't commit _most_ of the results)

and had to also do

```diff
diff --git a/Uebersicht/UBWindowsController.m b/Uebersicht/UBWindowsController.m
index 7e1e8ec..bad15e8 100644
--- a/Uebersicht/UBWindowsController.m
+++ b/Uebersicht/UBWindowsController.m
@@ -11,7 +11,6 @@
 #import "WKInspector.h"
 #import "WKView.h"
 #import "WKPage.h"
-#import "WKWebViewInternal.h"
 
 @import WebKit;
 
```
(as there is apparently a different / potentially conflicting definition brought in indirectly?; but that may be more a Monterey thing than an M1 thing )

still a bunch of warnings in the build, but the product has gotten me to:

![CleanShot 2021-08-02 at 17 51 01@2x](https://user-images.githubusercontent.com/43136/127928496-45005414-c94c-45b5-be0e-c948a58a05d3.png)

so more than none-widgets are working (though not the one I was setting up, necessarily)