### PR TITLE
Ensure Same Host

### DIFF
--- a/server/src/ensureSameHost.js
+++ b/server/src/ensureSameHost.js
@@ -1,0 +1,9 @@
+module.exports = function ensureSameHost(host) {
+    return ((req, res, next) => {
+        if (req.headers.host && req.headers.host === host) {
+            return next()
+        }
+        res.writeHead(400)
+        res.end()
+    })
+}


### PR DESCRIPTION
Prevent [DNS rebinding attacks](https://en.wikipedia.org/wiki/DNS_rebinding) by checking the `Host` header.  This is not strictly necessary since such attacks should already be mitigated by the `Origin` header checks.  It is good practice to ensure that the `Host` is correct, if not for the sake of completeness.  There may be some situations where `Origin` is correct but `Host` is not (I'm having a hard time thinking of an example right now, though, to be honest).

### Contrived PoC via CLI

Since the server currently does not check whether the `Host` header matches its expected value, one can use any domain name that maps to `127.0.0.1`.

```
❯ fgrep malicious /etc/hosts
127.0.0.1 malicious.example.com
❯ dscacheutil -q host -a name malicious.example.com
name: malicious.example.com
ip_address: 127.0.0.1
❯ curl -i 'http://malicious.example.com:41416/run/' -H'Origin:http://127.0.0.1:41416' -d'echo hello'
HTTP/1.1 200 OK
X-Frame-Options: sameorigin
Date: Mon, 22 Aug 2022 05:42:56 GMT
Connection: keep-alive
Keep-Alive: timeout=35
Transfer-Encoding: chunked

hello
```

The solution proposed here is to deny requests that have bad `Host` headers (i.e., not `127.0.0.1:41416`) by returning status code 400, since they are bad requests.

```
❯ curl -i 'http://malicious.example.com:41416/run/' -H'Origin:http://127.0.0.1:41416' -d'echo hello'
HTTP/1.1 400 Bad Request
X-Frame-Options: sameorigin
Date: Mon, 22 Aug 2022 05:44:40 GMT
Connection: keep-alive
Keep-Alive: timeout=35
Transfer-Encoding: chunked
```