### PR TITLE
Update label for opening on login

### DIFF
--- a/Uebersicht/UBPreferencesController.xib
+++ b/Uebersicht/UBPreferencesController.xib
@@ -57,7 +57,7 @@
                     <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="178">
                         <rect key="frame" x="220" y="198" width="205" height="18"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                        <buttonCell key="cell" type="check" title="Launch Übersicht when I login" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="179">
+                        <buttonCell key="cell" type="check" title="Open at Login" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="179">
                             <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                             <font key="font" metaFont="system"/>
                         </buttonCell>


### PR DESCRIPTION
This pull request slightly changes the wording of a checkbox.

Versions of macOS before Ventura used "These items will open automatically when you log in" in System Preferences but as of macOS 13, "Open at Login" is now used in System Settings. It seems to make sense to use "open", as Apple favors it over "start" or "launch".