### PR TITLE
✨ Add always-on-top preference

### DIFF
--- a/Uebersicht/UBAppDelegate.h
+++ b/Uebersicht/UBAppDelegate.h
@@ -20,6 +20,7 @@
 
 - (void)widgetDirDidChange;
 - (void)interactionDidChange;
+- (void)alwaysOnTopDidChange;
 - (void)screensChanged:(NSDictionary*)screens;
 - (IBAction)showPreferences:(id)sender;
 - (IBAction)openWidgetDir:(id)sender;

--- a/Uebersicht/UBAppDelegate.m
+++ b/Uebersicht/UBAppDelegate.m
@@ -295,6 +295,7 @@ int const PORT = 41416;
             updateWindows:screens
             baseUrl: [self serverUrl: @"http"]
             interactionEnabled: preferences.enableInteraction
+            alwaysOnTop: preferences.alwaysOnTop
             forceRefresh: needsRefresh
         ];
         needsRefresh = NO;
@@ -317,6 +318,13 @@ int const PORT = 41416;
 }
 
 - (void)interactionDidChange
+{
+    [windowsController closeAll];
+    needsRefresh = YES;
+    [screensController syncScreens];
+}
+
+- (void)alwaysOnTopDidChange
 {
     [windowsController closeAll];
     needsRefresh = YES;

--- a/Uebersicht/UBPreferencesController.h
+++ b/Uebersicht/UBPreferencesController.h
@@ -20,6 +20,7 @@
 @property NSURL* widgetDir;
 @property BOOL loginShell;
 @property BOOL enableInteraction;
+@property BOOL alwaysOnTop;
 
 - (IBAction)showFilePicker:(id)sender;
 

--- a/Uebersicht/UBPreferencesController.m
+++ b/Uebersicht/UBPreferencesController.m
@@ -197,6 +197,24 @@
 }
 
 #
+#pragma mark Always On Top
+#
+
+
+- (BOOL)alwaysOnTop
+{
+    NSUserDefaults* defaults = [NSUserDefaults standardUserDefaults];
+    return [[defaults valueForKey:@"alwaysOnTop"] boolValue];
+}
+
+- (void)setAlwaysOnTop:(BOOL)enabled
+{
+    NSUserDefaults* defaults = [NSUserDefaults standardUserDefaults];
+    [defaults setObject:@(enabled) forKey:@"alwaysOnTop"];
+    [(UBAppDelegate *)[NSApp delegate] alwaysOnTopDidChange];
+}
+
+#
 #pragma mark Startup
 #
 

--- a/Uebersicht/UBPreferencesController.xib
+++ b/Uebersicht/UBPreferencesController.xib
@@ -17,16 +17,16 @@
         <window title="Preferences" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" restorable="NO" releasedWhenClosed="NO" visibleAtLaunch="NO" animationBehavior="default" id="1">
             <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" resizable="YES"/>
             <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
-            <rect key="contentRect" x="472" y="636" width="580" height="236"/>
+            <rect key="contentRect" x="472" y="636" width="580" height="280"/>
             <rect key="screenRect" x="0.0" y="0.0" width="2560" height="1415"/>
-            <value key="minSize" type="size" width="580" height="236"/>
-            <value key="maxSize" type="size" width="580" height="236"/>
+            <value key="minSize" type="size" width="580" height="280"/>
+            <value key="maxSize" type="size" width="580" height="280"/>
             <view key="contentView" autoresizesSubviews="NO" id="2">
-                <rect key="frame" x="0.0" y="0.0" width="580" height="236"/>
+                <rect key="frame" x="0.0" y="0.0" width="580" height="280"/>
                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                 <subviews>
                     <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="5">
-                        <rect key="frame" x="116" y="170" width="100" height="16"/>
+                        <rect key="frame" x="116" y="214" width="100" height="16"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Widgets Folder:" id="8">
                             <font key="font" metaFont="system"/>
@@ -35,7 +35,7 @@
                         </textFieldCell>
                     </textField>
                     <popUpButton autoresizesSubviews="NO" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="43">
-                        <rect key="frame" x="220" y="164" width="286" height="25"/>
+                        <rect key="frame" x="220" y="208" width="286" height="25"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                         <popUpButtonCell key="cell" type="push" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" borderStyle="border" imageScaling="proportionallyDown" inset="2" arrowPosition="arrowAtCenter" id="44">
                             <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
@@ -55,7 +55,7 @@
                         </popUpButtonCell>
                     </popUpButton>
                     <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="178">
-                        <rect key="frame" x="220" y="198" width="205" height="18"/>
+                        <rect key="frame" x="220" y="242" width="205" height="18"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                         <buttonCell key="cell" type="check" title="Launch Übersicht when I login" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="179">
                             <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -66,7 +66,7 @@
                         </connections>
                     </button>
                     <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="255">
-                        <rect key="frame" x="163" y="200" width="53" height="16"/>
+                        <rect key="frame" x="163" y="244" width="53" height="16"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Startup:" id="256">
                             <font key="font" metaFont="system"/>
@@ -84,7 +84,7 @@
                         </textFieldCell>
                     </textField>
                     <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="R1C-8t-EyM">
-                        <rect key="frame" x="145" y="137" width="126" height="17"/>
+                        <rect key="frame" x="145" y="181" width="126" height="17"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Interaction:" id="8lm-M5-ekh">
                             <font key="font" metaFont="system"/>
@@ -93,7 +93,7 @@
                         </textFieldCell>
                     </textField>
                     <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="jHv-DY-0s5">
-                        <rect key="frame" x="220" y="136" width="132" height="18"/>
+                        <rect key="frame" x="220" y="180" width="132" height="18"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                         <buttonCell key="cell" type="check" title="Enable interaction" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="7vp-gG-U0H">
                             <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -101,6 +101,26 @@
                         </buttonCell>
                         <connections>
                             <binding destination="-2" name="value" keyPath="enableInteraction" id="all-KL-ihA"/>
+                        </connections>
+                    </button>
+                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="aot-label">
+                        <rect key="frame" x="119" y="137" width="97" height="17"/>
+                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Window Level:" id="aot-label-cell">
+                            <font key="font" metaFont="system"/>
+                            <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                        </textFieldCell>
+                    </textField>
+                    <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="aot-checkbox">
+                        <rect key="frame" x="220" y="136" width="132" height="18"/>
+                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                        <buttonCell key="cell" type="check" title="Always on top" bezelStyle="regularSquare" imagePosition="left" inset="2" id="aot-checkbox-cell">
+                            <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                            <font key="font" metaFont="system"/>
+                        </buttonCell>
+                        <connections>
+                            <binding destination="-2" name="value" keyPath="alwaysOnTop" id="aot-binding"/>
                         </connections>
                     </button>
                     <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="JRx-iq-tIq">
@@ -125,9 +145,9 @@
                         </textFieldCell>
                     </textField>
                     <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" fixedFrame="YES" preferredMaxLayoutWidth="268" translatesAutoresizingMaskIntoConstraints="NO" id="VVJ-Cl-FSt">
-                        <rect key="frame" x="239" y="88" width="312" height="42"/>
+                        <rect key="frame" x="239" y="88" width="312" height="56"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                        <textFieldCell key="cell" controlSize="small" sendsActionOnEndEditing="YES" title="Disable if you don't want widgets to be clickable and always stay behind items on your desktop." id="GmJ-aJ-oHW">
+                        <textFieldCell key="cell" controlSize="small" sendsActionOnEndEditing="YES" title="Disable interaction if you don't want widgets to be clickable. Enable Always on top to keep widgets visible above other windows." id="GmJ-aJ-oHW">
                             <font key="font" metaFont="label" size="11"/>
                             <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                             <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>

--- a/Uebersicht/UBWindow.h
+++ b/Uebersicht/UBWindow.h
@@ -16,7 +16,8 @@
 typedef NS_ENUM(NSInteger, UBWindowType) {
     UBWindowTypeAgnostic,
     UBWindowTypeBackground,
-    UBWindowTypeForeground
+    UBWindowTypeForeground,
+    UBWindowTypeAlwaysOnTop
 };
 
 

--- a/Uebersicht/UBWindow.m
+++ b/Uebersicht/UBWindow.m
@@ -134,6 +134,10 @@
             [self setLevel:kCGNormalWindowLevel-1];
             [self updateTrackingArea];
             break;
+        case UBWindowTypeAlwaysOnTop:
+            [self setLevel:kCGFloatingWindowLevel];
+            [self updateTrackingArea];
+            break;
         case UBWindowTypeBackground:
         case UBWindowTypeAgnostic:
             [self setLevel:kCGDesktopWindowLevel];
@@ -157,10 +161,10 @@
 #pragma mark flags
 #
 
-- (BOOL)isKeyWindow { return type == UBWindowTypeForeground; }
-- (BOOL)canBecomeKeyWindow { return type == UBWindowTypeForeground; }
-- (BOOL)canBecomeMainWindow { return type == UBWindowTypeForeground; }
-- (BOOL)acceptsFirstResponder { return type == UBWindowTypeForeground; }
-- (BOOL)acceptsMouseMovedEvents { return type == UBWindowTypeForeground;; }
+- (BOOL)isKeyWindow { return type == UBWindowTypeForeground || type == UBWindowTypeAlwaysOnTop; }
+- (BOOL)canBecomeKeyWindow { return type == UBWindowTypeForeground || type == UBWindowTypeAlwaysOnTop; }
+- (BOOL)canBecomeMainWindow { return type == UBWindowTypeForeground || type == UBWindowTypeAlwaysOnTop; }
+- (BOOL)acceptsFirstResponder { return type == UBWindowTypeForeground || type == UBWindowTypeAlwaysOnTop; }
+- (BOOL)acceptsMouseMovedEvents { return type == UBWindowTypeForeground || type == UBWindowTypeAlwaysOnTop; }
 
 @end

--- a/Uebersicht/UBWindowGroup.h
+++ b/Uebersicht/UBWindowGroup.h
@@ -16,7 +16,8 @@ NS_ASSUME_NONNULL_BEGIN
 @property (readonly, strong) UBWindow* foreground;
 @property (readonly, strong) UBWindow* background;
 
-- (id)initWithInteractionEnabled:(BOOL)interactionEnabled;
+- (id)initWithInteractionEnabled:(BOOL)interactionEnabled
+                     alwaysOnTop:(BOOL)alwaysOnTop;
 - (void)loadUrl:(NSURL*)Url;
 - (void)reload;
 - (void)close;

--- a/Uebersicht/UBWindowGroup.m
+++ b/Uebersicht/UBWindowGroup.m
@@ -16,16 +16,20 @@
 
 
 - (id)initWithInteractionEnabled:(BOOL)interactionEnabled
+                     alwaysOnTop:(BOOL)alwaysOnTop
 {
     self = [super init];
     if (self) {
-        if (interactionEnabled) {
+        if (interactionEnabled || alwaysOnTop) {
+            UBWindowType foregroundType = alwaysOnTop
+                ? UBWindowTypeAlwaysOnTop
+                : UBWindowTypeForeground;
             foreground = [[UBWindow alloc]
-                initWithWindowType: UBWindowTypeForeground
+                initWithWindowType: foregroundType
             ];
             [foreground orderFront:self];
         }
-        
+
         background = [[UBWindow alloc]
             initWithWindowType: interactionEnabled
                 ? UBWindowTypeBackground

--- a/Uebersicht/UBWindowsController.h
+++ b/Uebersicht/UBWindowsController.h
@@ -16,6 +16,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)updateWindows:(NSDictionary*)screens
               baseUrl:(NSURL*)baseUrl
    interactionEnabled:(Boolean)interactionEnabled
+          alwaysOnTop:(Boolean)alwaysOnTop
          forceRefresh:(Boolean)forceRefresh;
 
 - (void)reloadAll;

--- a/Uebersicht/UBWindowsController.m
+++ b/Uebersicht/UBWindowsController.m
@@ -32,15 +32,17 @@
 - (void)updateWindows:(NSDictionary*)screens
               baseUrl:(NSURL*)baseUrl
    interactionEnabled:(Boolean)interactionEnabled
+          alwaysOnTop:(Boolean)alwaysOnTop
          forceRefresh:(Boolean)forceRefresh
 {
     NSMutableArray* obsoleteScreens = [[windows allKeys] mutableCopy];
     UBWindowGroup* windowGroup;
-    
+
     for(NSNumber* screenId in screens) {
         if (![windows objectForKey:screenId]) {
             windowGroup = [[UBWindowGroup alloc]
                 initWithInteractionEnabled: interactionEnabled
+                alwaysOnTop: alwaysOnTop
             ];
             [windows setObject:windowGroup forKey:screenId];
             [windowGroup loadUrl: [self screenUrl:screenId baseUrl:baseUrl]];
@@ -50,16 +52,16 @@
                 [windowGroup reload];
             }
         }
-        
+
         [windowGroup setFrame:[self screenRect:screenId] display:YES];
         [obsoleteScreens removeObject:screenId];
     }
-    
+
     for (NSNumber* screenId in obsoleteScreens) {
         [windows[screenId] close];
         [windows removeObjectForKey:screenId];
     }
-    
+
     NSLog(@"using %lu screens", (unsigned long)[windows count]);
 }
 


### PR DESCRIPTION
## Summary

Adds a new "Always on top" checkbox in Preferences. When enabled, widgets float above all normal windows using `kCGFloatingWindowLevel`. Useful for monitoring dashboards and status widgets that should remain visible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)